### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -120,9 +120,40 @@ function escapeXml(unsafe: string): string {
   });
 }
 
+function validateOpmlInput(xmlText: string): string {
+  // Normalize to string and trim whitespace/BOM to reduce parser quirks.
+  let normalized = String(xmlText);
+  // Remove UTF-8 BOM if present
+  if (normalized.charCodeAt(0) === 0xfeff) {
+    normalized = normalized.slice(1);
+  }
+  normalized = normalized.trim();
+
+  // Reject unreasonably large inputs (basic DoS/XEE hardening).
+  const MAX_OPML_SIZE = 2 * 1024 * 1024; // 2MB
+  if (normalized.length === 0 || normalized.length > MAX_OPML_SIZE) {
+    throw new Error("無効なOPMLファイルです。");
+  }
+
+  // Basic shape check: must look like XML/OPML.
+  if (!normalized.startsWith("<") || !/<opml[\s>]/i.test(normalized)) {
+    throw new Error("OPMLファイルではない可能性があります。");
+  }
+
+  // Optionally reject obviously dangerous HTML constructs.
+  const dangerousPattern =
+    /<(script|iframe|object|embed|meta|link|style)\b[^>]*>/i;
+  if (dangerousPattern.test(normalized)) {
+    throw new Error("危険な要素を含むため、OPMLを読み込めません。");
+  }
+
+  return normalized;
+}
+
 export function parseSubscriptionsFromOpml(xmlText: string): Subscription[] {
+  const safeXmlText = validateOpmlInput(xmlText);
   const parser = new DOMParser();
-  const xmlDoc = parser.parseFromString(xmlText, "text/xml");
+  const xmlDoc = parser.parseFromString(safeXmlText, "text/xml");
   const parserError = xmlDoc.querySelector("parsererror");
 
   if (parserError) {
@@ -132,7 +163,9 @@ export function parseSubscriptionsFromOpml(xmlText: string): Subscription[] {
   return Array.from(xmlDoc.querySelectorAll("outline[xmlUrl]"))
     .map((node) => ({
       title:
-        node.getAttribute("title") || node.getAttribute("text") || "No Title",
+        node.getAttribute("title") ||
+        node.getAttribute("text") ||
+        "No Title",
       xmlUrl: node.getAttribute("xmlUrl") || "",
       htmlUrl: node.getAttribute("htmlUrl") || "",
       unreadCount: 0,

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -147,6 +147,19 @@ function validateOpmlInput(xmlText: string): string {
     throw new Error("危険な要素を含むため、OPMLを読み込めません。");
   }
 
+  // Reject generic HTML markup and inline handlers to avoid the text being
+  // interpreted as HTML in any downstream usage.
+  const htmlLikePattern =
+    /<(div|span|p|a|img|form|input|button|textarea|select|option|video|audio|canvas)\b[^>]*>/i;
+  const inlineHandlerOrJsUrlPattern =
+    /\bon\w+\s*=\s*["'][^"']*["']|javascript:/i;
+  if (
+    htmlLikePattern.test(normalized) ||
+    inlineHandlerOrJsUrlPattern.test(normalized)
+  ) {
+    throw new Error("危険な要素を含むため、OPMLを読み込めません。");
+  }
+
   return normalized;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ArcCosine/LLR/security/code-scanning/2](https://github.com/ArcCosine/LLR/security/code-scanning/2)

General approach: Avoid feeding raw untrusted text directly into `DOMParser` in a way that could interpret unexpected markup. Since we need XML structure to read OPML, the best we can do is (1) validate that the file is plausibly OPML/XML before parsing, and (2) ensure that whatever we extract from the parsed DOM is treated purely as text and not reinterpreted as HTML later. We can also reduce attack surface by trimming BOMs and rejecting obviously invalid content early.

Best concrete fix in this code: add a small validation/sanitization step in `parseSubscriptionsFromOpml` before calling `parseFromString`. This step checks that the input is a reasonably small, textual OPML/XML document (e.g., contains `<opml` or `<body>`, no `<script`/`<iframe` tags, bounded length), and throws an error if it does not. Additionally, we can normalize the extracted attribute values to safe strings (e.g., coerce null to empty string and trim whitespace). This retains all existing functionality (valid OPML imports continue to work) while making it significantly harder to abuse an uploaded file to produce a dangerous DOM.

What to change exactly:
- In `src/lib/feed.ts`, in `parseSubscriptionsFromOpml`, insert a lightweight `validateOpmlInput(xmlText: string)` helper before creating the `DOMParser`, and call it at the start of the function.
- Implement `validateOpmlInput` in the same file (no new dependencies). It should:
  - Ensure `xmlText` is a string.
  - Reject overly large input (e.g., > 2MB) to avoid pathological payloads.
  - Optionally strip a UTF-8 BOM and trim leading whitespace.
  - Check that it looks like OPML/XML (e.g., starts with `<` and contains `<opml` or `<body>`).
  - Optionally reject obviously dangerous HTML constructs (`<script`, `<iframe`, `<img` with `onerror`, etc.) to reduce the chance that the parsed XML tree is later misused.
- Still rely on the existing `parsererror` check after `parseFromString` to catch structural XML errors.

Only `src/lib/feed.ts` needs changes; `OpmlImportPanel.tsx` and `App.tsx` can remain untouched.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
