### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lucide-react": "^1.7.0",
     "node-html-parser": "^7.1.0",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "fast-xml-parser": "^5.5.10"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.0",

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -1,4 +1,5 @@
 import type { Article, Subscription } from "@/types";
+import { XMLParser } from "fast-xml-parser";
 
 export const RSS_API_BASE_URL =
   import.meta.env.VITE_RSS_API_BASE_URL ||
@@ -165,23 +166,82 @@ function validateOpmlInput(xmlText: string): string {
 
 export function parseSubscriptionsFromOpml(xmlText: string): Subscription[] {
   const safeXmlText = validateOpmlInput(xmlText);
-  const parser = new DOMParser();
-  const xmlDoc = parser.parseFromString(safeXmlText, "text/xml");
-  const parserError = xmlDoc.querySelector("parsererror");
 
-  if (parserError) {
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: "@_",
+    allowBooleanAttributes: true,
+    parseAttributeValue: false,
+    trimValues: true,
+  });
+
+  let opmlObj: unknown;
+  try {
+    opmlObj = parser.parse(safeXmlText);
+  } catch {
     throw new Error("OPMLの解析に失敗しました。");
   }
 
-  return Array.from(xmlDoc.querySelectorAll("outline[xmlUrl]"))
-    .map((node) => ({
-      title:
-        node.getAttribute("title") ||
-        node.getAttribute("text") ||
-        "No Title",
-      xmlUrl: node.getAttribute("xmlUrl") || "",
-      htmlUrl: node.getAttribute("htmlUrl") || "",
-      unreadCount: 0,
-    }))
+  // Expect a structure like { opml: { body: { outline: [...] } } }, but
+  // be defensive about possible nesting shapes.
+  const outlines: any[] = [];
+
+  const collectOutlines = (node: any): void => {
+    if (!node || typeof node !== "object") {
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      for (const child of node) {
+        collectOutlines(child);
+      }
+      return;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(node, "outline")) {
+      const o = (node as any).outline;
+      if (Array.isArray(o)) {
+        for (const child of o) {
+          outlines.push(child);
+          collectOutlines(child);
+        }
+      } else if (o && typeof o === "object") {
+        outlines.push(o);
+        collectOutlines(o);
+      }
+    }
+
+    for (const key of Object.keys(node)) {
+      if (key === "outline") continue;
+      collectOutlines((node as any)[key]);
+    }
+  };
+
+  if (
+    opmlObj &&
+    typeof opmlObj === "object" &&
+    (opmlObj as any).opml
+  ) {
+    collectOutlines((opmlObj as any).opml);
+  } else {
+    throw new Error("OPMLの解析に失敗しました。");
+  }
+
+  return outlines
+    .map((node) => {
+      const titleAttr = (node as any)["@_title"] as string | undefined;
+      const textAttr = (node as any)["@_text"] as string | undefined;
+      const xmlUrlAttr = (node as any)["@_xmlUrl"] as string | undefined;
+      const htmlUrlAttr = (node as any)["@_htmlUrl"] as string | undefined;
+
+      const xmlUrl = xmlUrlAttr ? String(xmlUrlAttr).trim() : "";
+
+      return {
+        title: (titleAttr || textAttr || "No Title") as string,
+        xmlUrl,
+        htmlUrl: htmlUrlAttr ? String(htmlUrlAttr) : "",
+        unreadCount: 0,
+      } satisfies Subscription;
+    })
     .filter((subscription) => subscription.xmlUrl.length > 0);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ArcCosine/LLR/security/code-scanning/3](https://github.com/ArcCosine/LLR/security/code-scanning/3)

In general, to fix this kind of issue you want to avoid feeding untrusted text into browser DOM/HTML parsing APIs (`DOMParser`, `innerHTML`, etc.), or else you must strongly constrain the parsing context and the allowed constructs. In this case, the simplest robust fix is to stop using `DOMParser` for OPML and instead parse the XML with a pure JavaScript XML/HTML parser library that does not involve the browser’s HTML/DOM interpreter. That breaks the “DOM text → DOM parse” tainted flow entirely while preserving functionality.

The best targeted fix here is:

- Replace the use of `DOMParser` in `parseSubscriptionsFromOpml` with a safe, non-DOM XML parser such as `fast-xml-parser`.
- Keep `validateOpmlInput` as an extra hardening layer, but no longer rely on the browser DOM for parsing.
- Only pick out the `outline` elements with an `xmlUrl` attribute from the parsed JSON structure produced by `fast-xml-parser`, mapping them to `Subscription` objects exactly as before.

Concretely in `src/lib/feed.ts`:

1. **Add an import for `fast-xml-parser`** at the top:  
   `import { XMLParser } from "fast-xml-parser";`
2. **Rewrite `parseSubscriptionsFromOpml`**:
   - Keep the call to `validateOpmlInput(xmlText)` to obtain `safeXmlText`.
   - Instantiate `XMLParser` with safe options (ignore comments, process attributes, etc.).
   - Parse `safeXmlText` into a JS object.
   - Normalize the OPML structure to find all `<outline>` elements (which are often nested inside `<body>` / `<outline>` containers).
   - For each outline that has an `xmlUrl` attribute (in OPML, attributes will appear under something like `@_xmlUrl`), convert it to a `Subscription`:
     - `title` from `title` or `text` attributes (e.g., `node["@_title"] || node["@_text"] || "No Title"`).
     - `xmlUrl` and `htmlUrl` from `@_xmlUrl` / `@_htmlUrl`.
   - Filter out any entries with empty `xmlUrl`.

No other files need changes; `OpmlImportPanel.tsx` and `App.tsx` can remain as they are, since the vulnerable sink is in `parseSubscriptionsFromOpml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
